### PR TITLE
Fixes RNDFPBannerView to allow tap on a DFP Banner

### DIFF
--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -139,7 +139,7 @@ didReceiveAppEvent:(NSString *)name
 {
     [super layoutSubviews ];
 
-    _bannerView.frame = CGRectMake(
+    self.frame = CGRectMake(
                                    self.bounds.origin.x,
                                    self.bounds.origin.x,
                                    _bannerView.frame.size.width,


### PR DESCRIPTION
Fixes RNDFPBannerView frame to allow the user to tap on a DFP Banner.
This is related to #70.